### PR TITLE
WIP : Allow content type with media type parameters 

### DIFF
--- a/packages/openapi-to-graphql/src/oas_3_tools.ts
+++ b/packages/openapi-to-graphql/src/oas_3_tools.ts
@@ -152,7 +152,7 @@ export function getValidOAS3(spec: Oas2 | Oas3): Promise<Oas3> {
     ) {
       preprocessingLog(`Received OpenAPI Specification - going to validate...`)
 
-      OASValidator.validate(spec, {})
+      OASValidator.validate(spec, { anchors: true })
         .then(() => resolve(spec as Oas3))
         .catch((error) =>
           reject(
@@ -774,7 +774,7 @@ export function getResponseSchemaAndNames<TSource, TContext, TArgs>(
      * Edge case: if response body content-type is not application/json, do not
      * parse.
      */
-    if (responseContentType !== 'application/json') {
+    if (!responseContentType.includes('application/json')) {
       let description =
         'Placeholder to access non-application/json response bodies'
 


### PR DESCRIPTION
In a spec, specifying the content with media type [parameters](https://tools.ietf.org/html/rfc6838#section-4.3) ends up falling into the `Placeholder to access non-application/json response bodies` case when building the response types

Example:
```
content:
  application/json;foo=bar;version=1
```
